### PR TITLE
fix: correct alignment property in BodyEditor and CodeGenerator styles

### DIFF
--- a/src/components/BodyEditor/BodyEditor.module.scss
+++ b/src/components/BodyEditor/BodyEditor.module.scss
@@ -9,7 +9,7 @@
 .componentHeader {
   display: flex;
   justify-content: space-between;
-  align-items: end;
+  align-items: flex-end;
   gap: 10px;
   color: $color-white;
 }

--- a/src/components/CodeGenerator/CodeGenerator.module.scss
+++ b/src/components/CodeGenerator/CodeGenerator.module.scss
@@ -9,7 +9,7 @@
 .header {
   display: flex;
   justify-content: space-between;
-  align-items: end;
+  align-items: flex-end;
 }
 
 .header h3 {


### PR DESCRIPTION
fix: correct alignment property in BodyEditor and CodeGenerator styles